### PR TITLE
Fix  zeus radios+

### DIFF
--- a/cfg_containers.hpp
+++ b/cfg_containers.hpp
@@ -270,16 +270,6 @@ class cgqc_pack_mk1_magic : B_AssaultPack_rgr
     model = "\A3\weapons_f\empty";
     class TransportMagazines
     {
-        class _xx_ACE_Chemlight_HiRed
-        {
-            count = 1;
-            magazine = "ACE_Chemlight_HiRed";
-        };
-        class _xx_ACE_Chemlight_IR
-        {
-            count = 1;
-            magazine = "ACE_Chemlight_IR";
-        };
         class _xx_SmokeShell
         {
             count = 3;

--- a/functions/fnc_perksZeus.sqf
+++ b/functions/fnc_perksZeus.sqf
@@ -28,42 +28,45 @@ switch (_type) do {
 	};
 	case "zeus_radios":
 	{
-		_radios = call acre_api_fnc_getCurrentRadioList;  
-		{player removeItem _x;}forEach _radios;  
+		_radios = call acre_api_fnc_getCurrentRadioList;
+		sleep 0.5;  
+		{player removeItem _x;}forEach _radios;
+		sleep 0.5;  
 		// Add zeus radios  
 		if (player canAdd ["ACRE_PRC117F", 2]) then {   
-		// There is enough space, add the items   
-		player addItem "ACRE_PRC117F";   
-		player addItem "ACRE_PRC117F";   
+			// There is enough space, add the items 
+			hint "Enough space. Adding radios";  
+			player addItem "ACRE_PRC117F";   
+			player addItem "ACRE_PRC117F";   
 		} else {   
-		// There is not enough space   
-		hint "Not enough inventory space!";  
-		_items_pack = backpackItems player;  
-		removeBackpack player;  
-		player addBackpack "cgqc_pack_mk1_magic_zeus";  
-		clearAllItemsFromBackpack player;  
-		{player addItemToBackpack _x} forEach _items_pack;  
-		player addItem "ACRE_PRC117F";   
-		player addItem "ACRE_PRC117F";	
+			// There is not enough space   
+			hint "Not enough inventory space! Zeus backpack on";  
+			_items_pack = backpackItems player;  
+			removeBackpack player;  
+			player addBackpack "cgqc_pack_mk1_magic_zeus";  
+			clearAllItemsFromBackpack player;  
+			{player addItemToBackpack _x} forEach _items_pack;  
+			player addItem "ACRE_PRC117F";   
+			player addItem "ACRE_PRC117F";	
 		}; 
 		sleep 1;
-		_zeusRadios = ["ACRE_PRC117F"] call acre_api_fnc_getAllRadiosByType; 
-		waitUntil {sleep 1;!isNil "_zeusRadios"}; 
-		y_packRadio_1 = _zeusRadios select 0; 
-		y_packRadio_2 = _zeusRadios select 1; 
-		waitUntil {sleep 0.5;!isNil "_packRadio_1"}; 
-		_success = [_packRadio_1, 1] call acre_api_fnc_setRadioChannel; //Spartan 
-		waitUntil {sleep 1;!isNil "_packRadio_2"}; 
-		_success = [_packRadio_2, 9] call acre_api_fnc_setRadioChannel; //Air-Net 
+		y_zeusRadios = ["ACRE_PRC117F"] call acre_api_fnc_getAllRadiosByType; 
+		waitUntil {sleep 1;!isNil "y_zeusRadios"}; 
+		y_packRadio_1 = y_zeusRadios select 0; 
+		y_packRadio_2 = y_zeusRadios select 1; 
+		waitUntil {sleep 0.5;!isNil "y_packRadio_1"}; 
+		_success = [y_packRadio_1, 1] call acre_api_fnc_setRadioChannel; //Spartan 
+		waitUntil {sleep 1;!isNil "y_packRadio_2"}; 
+		_success = [y_packRadio_2, 9] call acre_api_fnc_setRadioChannel; //Air-Net 
 		// Set order
-		_success = [ [ _packRadio_1, _packRadio_2, "" ] ] call acre_api_fnc_setMultiPushToTalkAssignment; 
+		_success = [ [ y_packRadio_1, y_packRadio_2, "" ] ] call acre_api_fnc_setMultiPushToTalkAssignment; 
 		// Set sides  
-		_success = [_packRadio_1, "LEFT" ] call acre_api_fnc_setRadioSpatial; 
-		_success = [_packRadio_2, "RIGHT" ] call acre_api_fnc_setRadioSpatial; 
+		_success = [y_packRadio_1, "LEFT" ] call acre_api_fnc_setRadioSpatial; 
+		_success = [y_packRadio_2, "RIGHT" ] call acre_api_fnc_setRadioSpatial; 
 		hint parseText "<t> 
 		--- Zeus Radios -------------<br/> 
 		Radio1:Gauche/117/Spartan/HQ<br/>   
-		Radio2:Droite/117/Inter-Zeus</t>";
+		Radio2:Droite/117/Zeus</t>";
 		break;
 	};
 	case "maprestrict":

--- a/functions/fnc_postInit_client.sqf
+++ b/functions/fnc_postInit_client.sqf
@@ -153,6 +153,7 @@ player addEventHandler ["GetInMan", {
 
 //Sets radio channel names 
 [0] spawn CGQC_fnc_nameRadios;
+["radio_init"] execVM "\cgqc\functions\fnc_setRadios.sqf";
 
 // Boost dragging maximum 
 ACE_maxWeightDrag = 3000;

--- a/functions/fnc_preInit.sqf
+++ b/functions/fnc_preInit.sqf
@@ -121,6 +121,7 @@ cgqc_defense_done = false;
 cgqc_defense_start = false;
 // Helicopter training
 cgqc_training_heli = false;
+cgqc_heli_difficulty = 0;
 // Mortar training 
 cgqc_training_mortar = false;
 // KOTH training 
@@ -144,6 +145,7 @@ cgqc_cqb_civ = false;
 cgqc_cqb_nade = false;
 cgqc_cqb_tgt_move = 0;
 cgqc_cqb_tgt_static = 0;
+cgqc_cqb_paused = false;
 cgqc_cqb_hostile_class = ["O_G_Soldier_F", "O_G_Soldier_lite_F", "O_G_Soldier_SL_F"];
 cgqc_cqb_civ_class = ["C_journalist_F", "C_Journalist_01_War_F"];
 // *** Mk2 **********************
@@ -263,7 +265,7 @@ cgqc_config_mission_name = getMissionConfigValue "onLoadName";
 ["cgqc_config_ch8", "EDITBOX", ["Channel 8:", "Nom affiché dans le jeux"], 
     [_menu_name, "Radios"], "Libre"] call CBA_fnc_addSetting;
 ["cgqc_config_ch9", "EDITBOX", ["Channel 9:", "Nom affiché dans le jeux"], 
-    [_menu_name, "Radios"], "Inter/Zeus"] call CBA_fnc_addSetting;
+    [_menu_name, "Radios"], "Zeus"] call CBA_fnc_addSetting;
 
 // Briefing  ===============================================================================================
 ["cgqc_setting_briefingCmd_area","SLIDER", ["Commander's Briefing area size", "Square around the Zeus"],

--- a/functions/fnc_setRadios.sqf
+++ b/functions/fnc_setRadios.sqf
@@ -23,6 +23,19 @@ waitUntil {sleep 1;cgqc_postInitClient_done};
 
 //disableUserInput = true;
 	switch (_type) do {
+		case "radio_init":	{
+			_radios = call acre_api_fnc_getCurrentRadioList;
+			_radio_count = count _radios;
+			if (_radio_count > 0) then {
+				_radio_1 = _radios select 0;
+				_success = [_radio_1, "LEFT" ] call acre_api_fnc_setRadioSpatial;
+			};
+			if (_radio_count > 1) then {
+				_radio_2 = _radios select 1;
+				_side_2 = [_radio_2] call acre_api_fnc_getRadioSpatial;
+				_success = [_radio_2, "RIGHT" ] call acre_api_fnc_setRadioSpatial;
+			};
+		};
 		case "radio_sides":	{
 			_radios = call acre_api_fnc_getCurrentRadioList;
 			_radio_count = count _radios;

--- a/functions/fnc_setRadios.sqf
+++ b/functions/fnc_setRadios.sqf
@@ -243,6 +243,7 @@ waitUntil {sleep 1;cgqc_postInitClient_done};
 			Radio3:Droite/117/Centaure</t>";
 		};
 		case "recon": {
+			_personalRadio = ["ACRE_PRC343"] call acre_api_fnc_getRadioByType;
 			_handRadios = ["ACRE_PRC152"] call acre_api_fnc_getAllRadiosByType;
 			waitUntil {sleep 0.5;!isNil "_handRadios"};
 			_handRadio_1 = _handRadios select 0;
@@ -253,13 +254,15 @@ waitUntil {sleep 1;cgqc_postInitClient_done};
 			waitUntil {sleep 0.5;!isNil "_handRadio_2"};
 			[_handRadio_2, 1] call acre_api_fnc_setRadioChannel;
 			// Set sides 
+			_success = [_personalRadio, "LEFT" ] call acre_api_fnc_setRadioSpatial;
 			_success = [_handRadio_1, "LEFT" ] call acre_api_fnc_setRadioSpatial;
 			_success = [_handRadio_2, "RIGHT" ] call acre_api_fnc_setRadioSpatial;
 			// Set radio orders
-			_success = [ [ _handRadio_1, _handRadio_2, "" ] ] call acre_api_fnc_setMultiPushToTalkAssignment;
+			_success = [ [ _handRadio_1, _handRadio_2, _personalRadio] ] call acre_api_fnc_setMultiPushToTalkAssignment;
 			hintSilent parseText "<t>
 			Radio1:Gauche/152/Inter/Recon<br/> 
-			Radio2:Droite/152/Spartan-HQ</t>";
+			Radio2:Droite/152/Spartan-HQ<br/>
+			Radio3:Gauche/343/Spartan1</t>";
 		};
 		case "centaure_pieton":	{
 			_handRadios = ["ACRE_PRC152"] call acre_api_fnc_getAllRadiosByType;

--- a/loadouts/mk3_getStuff.sqf
+++ b/loadouts/mk3_getStuff.sqf
@@ -4,6 +4,48 @@
 _item = _this select 0;
 _skip = 0;
 switch (_item) do {
+	case "inf":
+	{
+		_radios = call acre_api_fnc_getCurrentRadioList;  
+		{player removeItem _x;}forEach _radios; 
+		sleep 0.5;
+		player addItem "ACRE_PRC343";
+		player addItem "ACRE_PRC148"; 
+		sleep 0.5;
+		["spartan", 1] execVM "\cgqc\functions\fnc_setRadios.sqf";
+	};
+	case "2ic":
+	{
+		_radios = call acre_api_fnc_getCurrentRadioList;  
+		{player removeItem _x;}forEach _radios;  
+		sleep 0.5;
+		player addItem "ACRE_PRC343";
+		player addItem "ACRE_PRC152"; 
+		sleep 0.5;
+		["spartan_2", 1] execVM "\cgqc\functions\fnc_setRadios.sqf";
+	};
+	case "tl":
+	{
+		_radios = call acre_api_fnc_getCurrentRadioList;  
+		{player removeItem _x;}forEach _radios;  
+		sleep 0.5;
+		player addItem "ACRE_PRC343";
+		player addItem "ACRE_PRC152"; 
+		player addItem "ACRE_PRC117F"; 
+		sleep 0.5;
+		["spartan_1", 1] execVM "\cgqc\functions\fnc_setRadios.sqf";
+	};
+	case "recon":
+	{
+		_radios = call acre_api_fnc_getCurrentRadioList;  
+		{player removeItem _x;}forEach _radios;  
+		sleep 0.5;
+		player addItem "ACRE_PRC152"; 
+		player addItem "ACRE_PRC152"; 
+		sleep 0.5;
+		["recon", 1] execVM "\cgqc\functions\fnc_setRadios.sqf";
+	};
+	
 	case "crate":
 	{
 		_pos_free = getPosATL player findEmptyPosition [1,20,"cgqc_box_mk2_arsenal"];

--- a/loadouts/mk3_menu.sqf
+++ b/loadouts/mk3_menu.sqf
@@ -86,59 +86,51 @@ if (hasInterface) then {
 					
 					// Spartan ------------------------------------------------------------------------------------------------------------
 					// **********************************************************************************************************************
-					_action = [ "menu_mk2_s1", "Spartan", "", {""}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					//_action = [ "menu_mk2_s1", "Spartan", "", {""}, {true} ] call ace_interact_menu_fnc_createAction;
+					//_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Infanterie ---------------------------------------------------------------------------------------------------------
 					_action = [ "menu_mk2_inf", "Infanterie", "", {""}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Rifleman mk18 
 					_action = [ "menu_mk2_inf_RFCQB", "Rifleman CQB mk18", "", {["rifle_cqb", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_inf"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_inf"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Rifleman M4
 					_action = [ "menu_mk2_inf_RF", "Rifleman Carbine M4blk2", "", {["rifle_carb", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_inf"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_inf"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Rifleman M16
 					_action = [ "menu_mk2_inf_RF_m16", "Rifleman Rifle M16a4", "", {["rifle_m16", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_inf"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_inf"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Grenadier 
 					_action = [ "menu_mk2_inf_Grenadier", "Grenadier", "", {["rifle_grenade", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_inf"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_inf"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Specialists ---------------------------------------------------------------------------------------------------------
 					_action = [ "menu_mk2_spec", "Spécialistes", "", {""}, {cgqc_player_rank > 1 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Medic 
 					_action = [ "menu_mk2_inf_medic", "Medic", "", {["med", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {cgqc_player_rank > 2 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Engineer
 					_action = [ "menu_mk2_inf_eng", "Engineer", "", {["eng", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {cgqc_player_rank > 2 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// MG (Light) 
 					_action = [ "menu_mk2_inf_LMG", "Light machinegun", "", {["lmg", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					//  MG (Heavy) 
 					_action = [ "menu_mk2_inf_HMG", "Heavy machinegun", "", {["hmg", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Marksman 
 					_action = [ "menu_mk2_inf_marks", "Marksman", "", {["mrksm", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {cgqc_player_rank > 2 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Anti-Tank (MAAWS)
 					_action = [ "menu_mk2_inf_maaws", "Anti-Tank (MAAWS)", "", {["at_maaws", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Anti-Tank (Javelin) 
 					_action = [ "menu_mk2_inf_jav", "Anti-Tank (Javelin)", "", {["at_jav", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// Mortier léger 
 					_action = [ "menu_mk2_inf_mortar", "Mortier Léger", "", {["mortar", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {cgqc_player_rank > 3 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
-					// Lead ---------------------------------------------------------------------------------------------------------
-					_action = [ "menu_mk2_lead", "Commandement", "", {""}, {cgqc_player_rank > 3 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1"], _action ] call  ace_interact_menu_fnc_addActionToObject;
-					// Team Leader 
-					_action = [ "menu_mk2_inf_TL", "Team Leader", "", {["tl_carb", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_lead"], _action ] call  ace_interact_menu_fnc_addActionToObject;
-					// Team Leader CQB
-					_action = [ "menu_mk2_inf_TLcqb", "Team Leader CQB", "", {["tl_cqb", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_s1", "menu_mk2_lead"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_spec"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					
 					// Recon ------------------------------------------------------------------------------------------------------------
 					_action = [ "menu_mk2_recon", "Recon", "", {""}, {cgqc_player_rank > 3 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
 					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2"], _action ] call ace_interact_menu_fnc_addActionToObject;
@@ -181,19 +173,30 @@ if (hasInterface) then {
 					_action = [ "menu_mk2_crew", "Tank Crew", "", {["tank_crew", 0, false, player] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
 					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_driver"], _action ] call ace_interact_menu_fnc_addActionToObject;
 					
+					// Lead ---------------------------------------------------------------------------------------------------------
+					_action = [ "menu_mk2_lead", "Commandement", "", {""}, {cgqc_player_rank > 3 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					// Team Leader 
+					_action = [ "menu_mk2_inf_TL", "Team Leader", "", {["tl_carb", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_lead"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					// Team Leader CQB
+					_action = [ "menu_mk2_inf_TLcqb", "Team Leader CQB", "", {["tl_cqb", 1, false] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023", "menu_mk2", "menu_mk2_lead"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					
 					// High Command ------------------------------------------------------------------------------------------------------------
-					_action = [ "menu_mk2_highCommand", "High Command", "", {}, {cgqc_player_rank > 5 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					//_action = [ "menu_mk2_highCommand", "High Command", "", {}, {cgqc_player_rank > 5 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
+					//_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					// SL 
+					_action = [ "menu_mk2_inf_sl", "Squad Leader", "", {["sl", 0, false, player] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2", "menu_mk2_lead"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					// HQ 
 					_action = [ "menu_mk2_inf_hq", "HQ", "", {["hq", 0, false, player] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2", "menu_mk2_highCommand"], _action ] call  ace_interact_menu_fnc_addActionToObject;
-					// HQ 
-					_action = [ "menu_mk2_inf_sl", "Squad Leader", "", {["sl", 0, false, player] execVM "\CGQC_2022\loadouts\mk2_role_switch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
-					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2", "menu_mk2_highCommand"], _action ] call  ace_interact_menu_fnc_addActionToObject;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2", "menu_mk2_lead"], _action ] call  ace_interact_menu_fnc_addActionToObject;
 					
+
 					
 					// Mk1 Camo Switcher ---------------------------------------------------------------------------------------------------------
-					_action = [ "menu_mk2_camo", "Camo/Uniformes", "CGQC\textures\icon_camo", {""}, {!cgqc_perks_ghillie_isOn} ] call ace_interact_menu_fnc_createAction;
+					_action = [ "menu_mk2_camo", "Switch: Camo", "CGQC\textures\icon_camo", {""}, {!cgqc_perks_ghillie_isOn} ] call ace_interact_menu_fnc_createAction;
 					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" ], _action ] call ace_interact_menu_fnc_addActionToObject;
 					// Base/Training uniform 
 					_action = [ "menu_mk2_camo_base", "Training - Vert", "", {["tan", false] execVM "\CGQC\loadouts\mk3_camoSwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
@@ -220,7 +223,53 @@ if (hasInterface) then {
 					_action = [ "menu_mk2_camo_diver_std", "Kit: Plongeur", "\CGQC\textures\cgqc_ace_dive", {["diver", false] execVM "\CGQC\loadouts\mk3_camoSwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
 					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_camo"], _action ] call ace_interact_menu_fnc_addActionToObject;
 				
-
+					// Alternative Primaries ---------------------------------------------------------------------------------------------------------
+					_action = [ "menu_mk2_alt", "Switch: Primary", "", {""}, {cgqc_player_rank > 2 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" ], _action ] call ace_interact_menu_fnc_addActionToObject;
+					// Categories
+					_action = [ "menu_mk2_alt_556", "5.56", "", {""}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_GL", "GL", "", {""}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_dmr", "DMR/Sniper", "", {""}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_mg", "MG", "", {""}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_others", "Others", "", {""}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt"], _action ] call ace_interact_menu_fnc_addActionToObject;
+				
+					// 5.56
+					_action = [ "menu_mk2_alt_mk18", '10in Mk18 Dot', "", {["mk18_dot"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_556"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_m4dot", '14in M4blkII Dot+', "", {["m4_dotplus"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_556"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_m4lpvo", '14in M4blkII LPVO', "", {["m4_lpvo"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_556"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_mk12", '18in Mk12 LPVO', "", {["mk12_lpvo"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_556"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_m16lpvo", '20in M16a4 LPVO', "", {["m16_shortdot"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_556"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					
+					// GL
+					_action = [ "menu_mk2_alt_mk18gl", '10in Mk18', "", {["mk18_gl"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_GL"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_m320", '14in M4blkII', "", {["m4_gl_m320"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_GL"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					// DMR/Sniper 
+					_action = [ "menu_mk2_alt_417", 'HK417 7.62mm', "", {["417"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_dmr"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_m14ebr", 'M14EBR 7.62mm', "", {["m14ebr"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_dmr"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_m200", 'm200 .408', "", {["m200"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_dmr"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					// MG
+					_action = [ "menu_mk2_alt_mk46", 'mk46 5.56mm', "", {["mk46"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_mg"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					_action = [ "menu_mk2_alt_mk48", 'mk48 7.62mm', "", {["mk48"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_mg"], _action ] call ace_interact_menu_fnc_addActionToObject;
+					// Others 
+					_action = [ "menu_mk2_alt_p90", 'P90 9mm', "", {["p90"] execVM "\CGQC\loadouts\mk3_primarySwitch.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+					_adding = [ _crate, 0, ["ACE_MainActions", "menu_2023" , "menu_mk2_alt", "menu_mk2_alt_others"], _action ] call ace_interact_menu_fnc_addActionToObject;
 
 					// 2023 arsenal ---------------------------------------------------------------------------------------------------
 
@@ -333,13 +382,15 @@ if (hasInterface) then {
 			//Radios 
 			_action = [ "menu_items_radios", "Radios", "", {""}, {cgqc_player_isModern} ] call ace_interact_menu_fnc_createAction;       
 			_adding = [ _crate, 0, ["ACE_MainActions" , "menu_items"], _action ] call  ace_interact_menu_fnc_addActionToObject;
-			_action = [ "menu_items1", "Radio: 343", "", {["343"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+		
+			// Individual radios 
+			_action = [ "menu_items1", "Get: 343", "", {["343"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
 			_adding = [ _crate, 0, ["ACE_MainActions" , "menu_items","menu_items_radios"], _action ] call ace_interact_menu_fnc_addActionToObject;
-			_action = [ "menu_items2", "Radio: 152", "", {["152"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+			_action = [ "menu_items2", "Get: 152", "", {["152"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
 			_adding = [ _crate, 0, ["ACE_MainActions" , "menu_items","menu_items_radios"], _action ] call ace_interact_menu_fnc_addActionToObject;
-			_action = [ "menu_items3", "Radio: 148", "", {["148"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+			_action = [ "menu_items3", "Get: 148", "", {["148"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
 			_adding = [ _crate, 0, ["ACE_MainActions" , "menu_items","menu_items_radios"], _action ] call ace_interact_menu_fnc_addActionToObject;
-			_action = [ "menu_items3", "Radio: 117f", "", {["117"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+			_action = [ "menu_items3", "Get: 117f", "", {["117"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
 			_adding = [ _crate, 0, ["ACE_MainActions" , "menu_items","menu_items_radios"], _action ] call ace_interact_menu_fnc_addActionToObject;
 			//Radios Vietnam 
 			_action = [ "menu_items52", "Radio: Short-Range", "", {["52"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {cgqc_player_hasUnsung} ] call ace_interact_menu_fnc_createAction;
@@ -375,7 +426,7 @@ if (hasInterface) then {
 			};
 
 			// Skill switcher ========================================================================================================
-			_action = [ "menu_skill", "Skills", "CGQC\textures\icon_skills", {""}, {cgqc_player_rank > 2 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
+			_action = [ "menu_skill", "Switch: Skills", "CGQC\textures\icon_skills", {""}, {cgqc_player_rank > 2 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining} ] call ace_interact_menu_fnc_createAction;
 			_adding = [ _crate, 0, ["ACE_MainActions" ], _action ] call  ace_interact_menu_fnc_addActionToObject;
 			// Medic
 			_action = [ "skill_medic", "Medic", "", {["medic"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
@@ -401,6 +452,17 @@ if (hasInterface) then {
 				{(cgqc_player_rank > 3 || !cgqc_mk2_arsenal_locked || cgqc_flag_isTraining) && (isNil "cgqc_perk_ghillie") && cgqc_player_isModern} 
 			] call ace_interact_menu_fnc_createAction;
 			_adding = [ _crate, 0, ["ACE_MainActions" ,"menu_skill"], _action ] call ace_interact_menu_fnc_addActionToObject; 
+
+			// Radio setups
+			_action = [ "menu_radios", "Switch: Radios", "CGQC\textures\radio.paa", {""}, {true} ] call ace_interact_menu_fnc_createAction;
+			_adding = [ _crate, 0, ["ACE_MainActions" ], _action ] call  ace_interact_menu_fnc_addActionToObject;
+			_action = [ "menu_items_tl", "Setup:Infantry 343+148", "", {["inf"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+			_adding = [ _crate, 0, ["ACE_MainActions" , "menu_radios"], _action ] call ace_interact_menu_fnc_addActionToObject; 
+			_action = [ "menu_items_tl", "Setup:2iC 343+152", "", {["2ic"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+			_adding = [ _crate, 0, ["ACE_MainActions", "menu_radios"], _action ] call ace_interact_menu_fnc_addActionToObject; 
+			_action = [ "menu_items_tl", "Setup:TL 343+152+117", "", {["tl"] execVM "\CGQC\loadouts\mk3_getStuff.sqf"}, {true} ] call ace_interact_menu_fnc_createAction;
+			_adding = [ _crate, 0, ["ACE_MainActions", "menu_radios"], _action ] call ace_interact_menu_fnc_addActionToObject;
+			
 
 			//Training ==============================================================================================================
 			//_action = [ "menu_training", "Training Mode", "", {hint "Check ton Ace Self-Action";execVM "\cgqc\functions\fnc_trainingMenu.sqf"}, {!cgqc_training_mode} ] call ace_interact_menu_fnc_createAction;       

--- a/loadouts/mk3_primarySwitch.sqf
+++ b/loadouts/mk3_primarySwitch.sqf
@@ -1,0 +1,170 @@
+// --- primarySwitch ----------------------------------------------------------
+// Switch primary weapons
+_type = _this select 0;
+_needGL = false;
+_mag_count = 6; 
+
+//Remove main weapon and mags 
+_gun = primaryWeapon player;
+player action ['SwitchWeapon', player, player, 250];
+sleep 0.5;
+if (_gun != "") then {
+	_mags = primaryWeaponMagazine player;
+	_mainMag = _mags select 0;
+	sleep 0.5;
+	if (count _mainMag > 0) then {
+		player removeMagazines _mainMag;
+	};
+	if (count _mags > 1) then {
+		player removeMagazines "1Rnd_HE_Grenade_shell";
+		player removeMagazines "1Rnd_Smoke_Grenade_shell";
+		player removeMagazines "1Rnd_SmokeBlue_Grenade_shell";
+		player removeMagazines "1Rnd_SmokeRed_Grenade_shell";
+		player removeMagazines "ACE_40mm_Flare_white";
+		player removeMagazines "UGL_FlareRed_F";
+		player removeMagazines "ACE_40mm_Flare_ir";
+	};
+	player removeWeapon _gun;
+};
+
+// Add gun
+switch (_type) do {
+	// Default guts ========================================================================
+	case "mk18_dot":{
+		["cgqc_gun_mk1_mk18"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_KAC_556_QDC_CQB_Black";
+		player addPrimaryWeaponItem "Tier1_M4BII_NGAL_M600V_Black";
+		player addPrimaryWeaponItem "tier1_exps3_0_black";
+		player addPrimaryWeaponItem "rhs_mag_30Rnd_556x45_Mk262_Stanag_Pull";
+	};
+	case "mk18_gl":{
+		["cgqc_gun_mk1_mk18_gl"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_KAC_556_QDC_CQB_Black";
+		player addPrimaryWeaponItem "Tier1_M4BII_NGAL_M600V_Black";
+		player addPrimaryWeaponItem "Tier1_Eotech551_L3_Black_Up";
+		player addPrimaryWeaponItem "rhs_mag_30Rnd_556x45_Mk262_Stanag_Pull";
+		player addPrimaryWeaponItem "1Rnd_HE_Grenade_shell";
+		_needGL = true;
+	};
+	case "m4_dotplus":{
+		["cgqc_gun_mk1_m4a1blkII"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_KAC_556_QDC_CQB_Black";
+		player addPrimaryWeaponItem "Tier1_M4BII_NGAL_M300C_Black";
+		player addPrimaryWeaponItem "Tier1_EXPS3_0_3xMag_Black_Up";
+		player addPrimaryWeaponItem "rhsusf_acc_grip2";
+		player addPrimaryWeaponItem "rhs_mag_30Rnd_556x45_Mk262_Stanag_Pull";
+	};
+	case "m4_lpvo":{ 
+		["cgqc_gun_mk1_m4a1blkII"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_KAC_556_QDC_CQB_Black";
+		player addPrimaryWeaponItem "Tier1_M4BII_NGAL_M600V_Black";
+		player addPrimaryWeaponItem "Tier1_Razor_Gen2_16_Geissele_Docter";
+		player addPrimaryWeaponItem "rhsusf_acc_grip2";
+		player addPrimaryWeaponItem "rhs_mag_30Rnd_556x45_Mk262_Stanag_Pull";
+	};
+	case "m4_gl_m320":{
+		["rhs_weap_m4_m320"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_KAC_556_QDC_CQB_Black";
+		player addPrimaryWeaponItem "Tier1_Mk18_NGAL_M300C_Black_FL";
+		player addPrimaryWeaponItem "Tier1_Razor_Gen2_16_Geissele_Docter";
+		player addPrimaryWeaponItem "rhs_mag_30Rnd_556x45_Mk262_Stanag_Pull";
+		player addPrimaryWeaponItem "1Rnd_HE_Grenade_shell";
+		_needGL = true;
+	};
+	case "m16_shortdot":{
+		["rhs_weap_m16a4_imod_grip2"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_KAC_556_QDC_CQB_Black";
+		player addPrimaryWeaponItem "Tier1_Mk18_NGAL_M300C_Black";
+		player addPrimaryWeaponItem "Tier1_Shortdot_Geissele_Docter_Black_PIP";
+		player addPrimaryWeaponItem "Tier1_Harris_Bipod_Black";
+		player addPrimaryWeaponItem "rhs_mag_30Rnd_556x45_Mk262_Stanag_Pull";
+	};
+	case "mk12_lpvo":{
+		["cgqc_gun_mk1_mk12"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_KAC_556_QDC_CQB_Black";
+		player addPrimaryWeaponItem "Tier1_M4BII_NGAL_M600V_Black";
+		player addPrimaryWeaponItem "Tier1_Razor_Gen3_110_Geissele_Docter";
+		player addPrimaryWeaponItem "rhs_mag_30Rnd_556x45_Mk262_Stanag_Pull";
+		player addPrimaryWeaponItem "Tier1_Harris_Bipod_Black";
+	};
+	case "417":{
+		["cgqc_gun_mk1_hk417"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_SandmanS_Black";
+		player addPrimaryWeaponItem "rhsusf_acc_anpeq15_bk_light";
+		player addPrimaryWeaponItem "Tier1_Razor_Gen3_110_Geissele_Docter";
+		player addPrimaryWeaponItem "ACE_20Rnd_762x51_M118LR_Mag";
+		player addPrimaryWeaponItem "bipod_01_F_blk";
+		_mag_count = 8;
+	};
+	case "mk46":{
+		["cgqc_gun_mk1_mk46"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_KAC_556_QDC_CQB_Black";
+		player addPrimaryWeaponItem "Tier1_Mk46Mod1_LA5_M600V_Black";
+		player addPrimaryWeaponItem "Tier1_EXPS3_0_3xMag_Black_Up";
+		player addPrimaryWeaponItem "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
+		player addPrimaryWeaponItem "Tier1_SAW_Bipod_DD";
+		_mag_count = 4;
+	};
+	case "mk48":{
+		["cgqc_gun_mk1_mk48"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "Tier1_SOCOM762MG_Black";
+		player addPrimaryWeaponItem "Tier1_Mk48Mod0_LA5_M600V_Black";
+		player addPrimaryWeaponItem "Tier1_EXPS3_0_3xMag_Black_Up";
+		player addPrimaryWeaponItem "Tier1_100Rnd_762x51_Belt_M993_AP";
+		player addPrimaryWeaponItem "Tier1_SAW_Bipod_2_KAC";
+		_mag_count = 5;
+	};
+	case "p90":{
+		["cgqc_gun_mk1_p90"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "muzzle_snds_570";
+		player addPrimaryWeaponItem "Tier1_NGAL_Side";
+		player addPrimaryWeaponItem "optic_ACO_grn";
+		player addPrimaryWeaponItem "50Rnd_570x28_SMG_03";
+		_mag_count = 4;
+	};
+	case "m14ebr":{
+		["rhs_weap_m14ebrri"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "rhsusf_acc_aac_762sdn6_silencer";
+		player addPrimaryWeaponItem "rhsusf_acc_nxs_3515x50f1_md";
+		player addPrimaryWeaponItem "rhsusf_acc_anpeq15side_bk";
+		player addPrimaryWeaponItem "rhs_acc_harris_swivel";
+		player addPrimaryWeaponItem "ACE_20Rnd_762x51_M118LR_Mag";
+		_mag_count = 9;
+	};
+	case "m200":{
+		["cgqc_gun_mk1_m200"] execVM "\CGQC_2022\functions\getCustomGun.sqf";sleep 0.5;
+		player addPrimaryWeaponItem "optic_lrps";
+		player addPrimaryWeaponItem "ace_acc_pointer_green";
+		player addPrimaryWeaponItem "7Rnd_mas_can_408_Mag";
+		_mag_count = 10;
+	};
+};
+
+sleep 1;
+// Add mags to vest 
+_mainMag = primaryWeaponMagazine player select 0;
+for "_i" from 1 to _mag_count do {
+	player addItem _mainMag;
+};
+
+if (_needGL) then {
+	player addItem "1Rnd_HE_Grenade_shell";
+	player addItem "1Rnd_HE_Grenade_shell";
+	player addItem "1Rnd_HE_Grenade_shell";
+	player addItem "1Rnd_HE_Grenade_shell";
+	player addItem "1Rnd_HE_Grenade_shell";
+	player addItem "1Rnd_Smoke_Grenade_shell";
+	player addItem "1Rnd_Smoke_Grenade_shell";
+	player addItem "1Rnd_SmokeBlue_Grenade_shell";
+	player addItem "1Rnd_SmokeBlue_Grenade_shell";
+	player addItem "1Rnd_SmokeRed_Grenade_shell";
+	player addItem "1Rnd_SmokeRed_Grenade_shell";
+	player addItem "ACE_40mm_Flare_white";
+	player addItem "UGL_FlareRed_F";
+	player addItem "ACE_40mm_Flare_ir";
+};
+
+player action ['SwitchWeapon', player, player, 100];
+hint "Primary weapon switched";
+sleep 5;
+hintSilent "";

--- a/loadouts/mk3_roleSwitch.sqf
+++ b/loadouts/mk3_roleSwitch.sqf
@@ -1,4 +1,5 @@
-
+// --- roleSwitch ----------------------------------------------------------
+// Switch roles
 waitUntil {!isNull (findDisplay 46)};
 waitUntil {cgqc_postInitClient_done};
 cgqc_roleSwitch_done = false;


### PR DESCRIPTION
Fix: Zeus radios
Ajout: Universal left/right init
Fix: Removed chemlights from magicpack
Ajout: Forced left/right
Ajout: Handle recon 343
Ajout: Get Radiosetup
Fix: Better role categories
Ajout: Switch primary
Fix: Channel 9 name